### PR TITLE
Networking cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 # Xcode
 
+## App Config
+*/.xccconfig
+
 ## User settings
 xcuserdata/
-
-## Obj-C/Swift specific
-*.hmap
 
 ## App packaging
 *.ipa
@@ -15,7 +15,7 @@ xcuserdata/
 timeline.xctimeline
 playground.xcworkspace
 
-## Xcode Patch
+## Xcode
 *.xcodeproj/*
 !*.xcodeproj/project.pbxproj
 !*.xcodeproj/xcshareddata/
@@ -25,33 +25,5 @@ playground.xcworkspace
 **/xcshareddata/WorkspaceSettings.xcsettings
 
 .build/
-
-# Carthage
-#
-# Add this line if you want to avoid checking in source code from Carthage dependencies.
-# Carthage/Checkouts
-
-Carthage/Build/
-
-# Accio dependency management
-Dependencies/
-.accio/
-
-# fastlane
-#
-# It is recommended to not store the screenshots in the git repo.
-# Instead, use fastlane to re-generate the screenshots whenever they are needed.
-# For more information about the recommended setup visit:
-# https://docs.fastlane.tools/best-practices/source-control/#source-control
-
-fastlane/report.xml
-fastlane/Preview.html
-fastlane/screenshots/**/*.png
-fastlane/test_output
-
-# Code Injection
-#
-# After new code Injection tools there's a generated folder /iOSInjectionProject
-# https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/

--- a/skinge-ios.xcodeproj/project.pbxproj
+++ b/skinge-ios.xcodeproj/project.pbxproj
@@ -10,7 +10,7 @@
 		CBBEE786290AED1700BE850B /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBBEE785290AED1600BE850B /* HTTPClient.swift */; };
 		CBBEE788290AED9600BE850B /* DataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBBEE787290AED9600BE850B /* DataStore.swift */; };
 		CBBEE78A290AEDD000BE850B /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBBEE789290AEDD000BE850B /* Constants.swift */; };
-		CBBEE792290B2A6200BE850B /* SkisViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBBEE791290B2A6200BE850B /* SkisViewModel.swift */; };
+		CBBEE792290B2A6200BE850B /* SkisList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBBEE791290B2A6200BE850B /* SkisList.swift */; };
 		CBCF5D70290AD5E3000965FF /* skinge_iosApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBCF5D6F290AD5E3000965FF /* skinge_iosApp.swift */; };
 		CBCF5D72290AD5E3000965FF /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBCF5D71290AD5E3000965FF /* ContentView.swift */; };
 		CBCF5D74290AD5E6000965FF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CBCF5D73290AD5E6000965FF /* Assets.xcassets */; };
@@ -45,7 +45,7 @@
 		CBBEE785290AED1600BE850B /* HTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
 		CBBEE787290AED9600BE850B /* DataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStore.swift; sourceTree = "<group>"; };
 		CBBEE789290AEDD000BE850B /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
-		CBBEE791290B2A6200BE850B /* SkisViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SkisViewModel.swift; sourceTree = "<group>"; };
+		CBBEE791290B2A6200BE850B /* SkisList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SkisList.swift; sourceTree = "<group>"; };
 		CBCF5D6C290AD5E3000965FF /* skinge-ios.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "skinge-ios.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CBCF5D6F290AD5E3000965FF /* skinge_iosApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = skinge_iosApp.swift; sourceTree = "<group>"; };
 		CBCF5D71290AD5E3000965FF /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -90,7 +90,7 @@
 		CBBEE790290B2A6200BE850B /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
-				CBBEE791290B2A6200BE850B /* SkisViewModel.swift */,
+				CBBEE791290B2A6200BE850B /* SkisList.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -329,7 +329,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CBBEE792290B2A6200BE850B /* SkisViewModel.swift in Sources */,
+				CBBEE792290B2A6200BE850B /* SkisList.swift in Sources */,
 				CBCF5D72290AD5E3000965FF /* ContentView.swift in Sources */,
 				CBBEE788290AED9600BE850B /* DataStore.swift in Sources */,
 				CBCF5D70290AD5E3000965FF /* skinge_iosApp.swift in Sources */,

--- a/skinge-ios/Src/Constants.swift
+++ b/skinge-ios/Src/Constants.swift
@@ -13,6 +13,7 @@ struct Constants {
         static let baseURL = "http://localhost:8080"
         static let productsPath = "/products"
         static let skisPath = "/skis/"
+        static let apiKey = "Bearer "
     }
 
 }

--- a/skinge-ios/Src/Utilities/HTTPClient.swift
+++ b/skinge-ios/Src/Utilities/HTTPClient.swift
@@ -7,6 +7,14 @@
 
 import Foundation
 
+enum HTTPMethods: String {
+    case DELETE = "DELETE"
+    case GET = "GET"
+    case PATCH = "PATCH"
+    case POST = "POST"
+    case PUT = "PUT"
+}
+
 class HTTPClient {
     
     // MARK: - Class Methods
@@ -16,22 +24,25 @@ class HTTPClient {
         guard let url = URL(string: url) else { return }
         
         var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("Bearer [REDACTED]",
+        request.httpMethod = HTTPMethods.GET.rawValue
+        request.setValue("Bearer ",
             forHTTPHeaderField: "Authorization")
+            
+        let sharedSession = URLSession.shared
         
-        let dataTask = URLSession.shared.dataTask(with: request) { (data, response, error) in
-            do {
-                if let jsonData = data {
-                    let decoder = JSONDecoder()
-                    decoder.keyDecodingStrategy = .convertFromSnakeCase
-                    let typedObject: T? = try decoder.decode(T.self, from: jsonData)
-                    completionHandler(typedObject)
+        let dataTask = sharedSession.dataTask(with: request) {
+            (data, response, error) in
+                do {
+                    if let jsonData = data {
+                        let decoder = JSONDecoder()
+                        decoder.keyDecodingStrategy = .convertFromSnakeCase
+                        let typedObject: T? = try decoder.decode(T.self, from: jsonData)
+                        completionHandler(typedObject)
+                    }
                 }
-            }
-            catch {
-                print(error)
-            }
+                catch {
+                    print(error)
+                }
         }
         
         dataTask.resume()

--- a/skinge-ios/Src/Utilities/HTTPClient.swift
+++ b/skinge-ios/Src/Utilities/HTTPClient.swift
@@ -25,8 +25,7 @@ class HTTPClient {
         
         var request = URLRequest(url: url)
         request.httpMethod = HTTPMethods.GET.rawValue
-        request.setValue("Bearer ",
-            forHTTPHeaderField: "Authorization")
+        request.setValue(Constants.API.apiKey, forHTTPHeaderField: "Authorization")
             
         let sharedSession = URLSession.shared
         

--- a/skinge-ios/Src/ViewModels/SkisList.swift
+++ b/skinge-ios/Src/ViewModels/SkisList.swift
@@ -12,6 +12,7 @@ class SkisViewModel: ObservableObject {
     // MARK: - Public Variables
     
     @Published var skis = [Ski]()
+    @Published var error = false
     
     // MARK: Init(s)
     
@@ -25,6 +26,7 @@ class SkisViewModel: ObservableObject {
         DataStore.getSkis { skis in
             guard let skis = skis else {
                 print("Something went wrong.")
+                self.error = true
                 return
             }
             DispatchQueue.main.async {

--- a/skinge-ios/Src/ViewModels/SkisList.swift
+++ b/skinge-ios/Src/ViewModels/SkisList.swift
@@ -8,15 +8,28 @@
 import Foundation
 
 class SkisViewModel: ObservableObject {
-    @Published var skis = [Ski]()
 
+    // MARK: - Public Variables
+    
+    @Published var skis = [Ski]()
+    
+    // MARK: Init(s)
+    
+    init() {
+        getSkis()
+    }
+    
+    // MARK: - Public Functions
+    
     func getSkis() {
         DataStore.getSkis { skis in
             guard let skis = skis else {
                 print("Something went wrong.")
                 return
             }
-            self.skis = skis
+            DispatchQueue.main.async {
+                self.skis = skis
+            }
         }
         print(skis)
     }

--- a/skinge-ios/Src/ViewModels/SkisList.swift
+++ b/skinge-ios/Src/ViewModels/SkisList.swift
@@ -25,7 +25,6 @@ class SkisViewModel: ObservableObject {
     func getSkis() {
         DataStore.getSkis { skis in
             guard let skis = skis else {
-                print("Something went wrong.")
                 self.error = true
                 return
             }

--- a/skinge-ios/Src/Views/ContentView.swift
+++ b/skinge-ios/Src/Views/ContentView.swift
@@ -8,7 +8,10 @@
 import SwiftUI
 
 struct ContentView: View {
-    @State private var skis = [Ski]()
+
+    // MARK: - Public Variables
+    
+    @ObservedObject var skisList: SkisViewModel
 
     var body: some View {
         NavigationView {
@@ -16,7 +19,7 @@ struct ContentView: View {
                 Text("Skis")
                     .font(.title)
                     .bold()
-                List(skis, id: \.id) { ski in
+                List(skisList.skis, id: \.id) { ski in
                     VStack(alignment: .leading) {
                         Text(ski.brand.name)
                             .italic()
@@ -27,29 +30,22 @@ struct ContentView: View {
                 .scrollContentBackground(.hidden)
                 .frame(maxWidth: .infinity)
                 .listStyle(SidebarListStyle())
-                .task {
-                    await loadSkis()
-                }
+                // .task {
+                //     await skisList.skis
+                // }
             }
             .navigationBarTitle("Skinge", displayMode: .inline)
         }
         .padding()
     }
-    
-    func loadSkis() async {
-        DataStore.getSkis { skis in
-            guard let skis = skis else {
-                print("Something went wrong.")
-                return
-            }
-            self.skis = skis
-        }
-    }
 
 }
 
+// MARK: Previews
+
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        ContentView()
+        let skisList = SkisViewModel()
+        ContentView(skisList: skisList)
     }
 }

--- a/skinge-ios/Src/Views/ContentView.swift
+++ b/skinge-ios/Src/Views/ContentView.swift
@@ -12,6 +12,8 @@ struct ContentView: View {
     // MARK: - Public Variables
     
     @ObservedObject var skisList: SkisViewModel
+    
+    // MARK: - Body
 
     var body: some View {
         NavigationView {
@@ -29,12 +31,11 @@ struct ContentView: View {
                 }
                 .scrollContentBackground(.hidden)
                 .frame(maxWidth: .infinity)
-                .listStyle(SidebarListStyle())
-                // .task {
-                //     await skisList.skis
-                // }
             }
             .navigationBarTitle("Skinge", displayMode: .inline)
+        }
+        .alert("Something went wrong", isPresented: $skisList.error) {
+            Button("OK") { }
         }
         .padding()
     }

--- a/skinge-ios/Src/skinge_iosApp.swift
+++ b/skinge-ios/Src/skinge_iosApp.swift
@@ -9,9 +9,11 @@ import SwiftUI
 
 @main
 struct skinge_iosApp: App {
+    private let skisList = SkisViewModel()
+    
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(skisList: skisList)
         }
     }
 }


### PR DESCRIPTION
# Networking cleanup

## Changes
- [Move all skis retrieval to the ViewModel](https://github.com/cassiewallace/skinge-ios/pull/4/commits/1dc50dd3d0441003e79e379107514b92c953f03b), which required some changes to using `@ObservableObject`
- Move API key to Constants (for now)
- Clean up `HTTPClient` implementation with an enum and some other code cleanup
- [Show alert if there's an issue with getting skis data](https://github.com/cassiewallace/skinge-ios/pull/4/commits/010534f51082c146e1be5abafc89bacf50cb82db); in future, this should be app-wide