### PR TITLE
Minor code cleanup from last PR

### DIFF
--- a/skinge-ios.xcodeproj/project.pbxproj
+++ b/skinge-ios.xcodeproj/project.pbxproj
@@ -222,9 +222,9 @@
 		CBCF5D9C290ADD13000965FF /* Src */ = {
 			isa = PBXGroup;
 			children = (
+				CBCF5D6F290AD5E3000965FF /* skinge_iosApp.swift */,
 				CBBEE790290B2A6200BE850B /* ViewModels */,
 				CBCF5D9D290ADD31000965FF /* Models */,
-				CBCF5D6F290AD5E3000965FF /* skinge_iosApp.swift */,
 				CBCF5D99290ADCA8000965FF /* Views */,
 				CBCF5D9A290ADCBE000965FF /* Utilities */,
 				CBBEE789290AEDD000BE850B /* Constants.swift */,

--- a/skinge-ios/Src/Constants.swift
+++ b/skinge-ios/Src/Constants.swift
@@ -20,6 +20,11 @@ struct Constants {
         case bindings
         case boots
         case skins
+        
+        func singularRawValue() -> String {
+            return rawValue.dropLast(1).capitalized
+        }
+        
     }
 
 }

--- a/skinge-ios/Src/Models/Product.swift
+++ b/skinge-ios/Src/Models/Product.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol Product {
+protocol Product: Codable {
 
     // MARK: - Variables
     

--- a/skinge-ios/Src/ViewModels/ProductListViewModel.swift
+++ b/skinge-ios/Src/ViewModels/ProductListViewModel.swift
@@ -49,19 +49,19 @@ class ProductListViewModel: ObservableObject {
     }
     
     func getBoots() {
-        getProducts(productType: Constants.ProductType.boots) { (boots: [Boot]) in
+        getProducts(productType: Constants.ProductType.boots) { boots in
             self.boots = boots
         }
     }
     
     func getSkis() {
-        getProducts(productType: Constants.ProductType.skis) { (skis: [Ski]) in
+        getProducts(productType: Constants.ProductType.skis) { skis in
             self.skis = skis
         }
     }
     
     func getSkins() {
-        getProducts(productType: Constants.ProductType.skins) { (skins: [Skin]) in
+        getProducts(productType: Constants.ProductType.skins) { skins in
             self.skins = skins
         }
     }

--- a/skinge-ios/Src/Views/ProductDetailView.swift
+++ b/skinge-ios/Src/Views/ProductDetailView.swift
@@ -47,8 +47,7 @@ struct ProductDetailView: View {
                 }
             }
         }
-        .navigationTitle("\(productType.rawValue.dropLast(1).capitalized) Details")
-        // TODO: Maybe this should be handled in the ViewModel or Enum.
+        .navigationTitle("\(productType.singularRawValue()) Details")
         .navigationBarTitleDisplayMode(.inline)
     }
     

--- a/skinge-ios/Src/skinge_iosApp.swift
+++ b/skinge-ios/Src/skinge_iosApp.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 @main
 struct skinge_iosApp: App {
-    private let skisList = ProductListViewModel()
     
     var body: some Scene {
         WindowGroup {


### PR DESCRIPTION
# Changes
- Rely on inferred types
- Create a `singularRawValue()` function on the ProductType enum so that we can retrieve it from anywhere instead of doing it just from the one view