### PR TITLE
Add loading indicator to product list

### DIFF
--- a/skinge-ios.xcodeproj/project.pbxproj
+++ b/skinge-ios.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		CBBAE556295CD6B200F374F1 /* BootVariant.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBBAE555295CD6B200F374F1 /* BootVariant.swift */; };
 		CBBAE558295CD6C800F374F1 /* SkinVariant.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBBAE557295CD6C800F374F1 /* SkinVariant.swift */; };
 		CBBAE55E295CE1CD00F374F1 /* SkiVariants.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBBAE55D295CE1CD00F374F1 /* SkiVariants.swift */; };
+		CBBAE560295E00FB00F374F1 /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBBAE55F295E00FB00F374F1 /* ErrorView.swift */; };
 		CBBEE786290AED1700BE850B /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBBEE785290AED1600BE850B /* HTTPClient.swift */; };
 		CBBEE788290AED9600BE850B /* DataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBBEE787290AED9600BE850B /* DataStore.swift */; };
 		CBBEE78A290AEDD000BE850B /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBBEE789290AEDD000BE850B /* Constants.swift */; };
@@ -71,6 +72,7 @@
 		CBBAE555295CD6B200F374F1 /* BootVariant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BootVariant.swift; sourceTree = "<group>"; };
 		CBBAE557295CD6C800F374F1 /* SkinVariant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkinVariant.swift; sourceTree = "<group>"; };
 		CBBAE55D295CE1CD00F374F1 /* SkiVariants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkiVariants.swift; sourceTree = "<group>"; };
+		CBBAE55F295E00FB00F374F1 /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
 		CBBEE785290AED1600BE850B /* HTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
 		CBBEE787290AED9600BE850B /* DataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStore.swift; sourceTree = "<group>"; };
 		CBBEE789290AEDD000BE850B /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
@@ -196,6 +198,7 @@
 				CB83FB22293A8A8A005863BB /* ProductListView.swift */,
 				CB06E657291B028F004BE837 /* ProductDetailView.swift */,
 				CBBAE55D295CE1CD00F374F1 /* SkiVariants.swift */,
+				CBBAE55F295E00FB00F374F1 /* ErrorView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -379,6 +382,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CBBAE560295E00FB00F374F1 /* ErrorView.swift in Sources */,
 				CBBEE792290B2A6200BE850B /* ProductListViewModel.swift in Sources */,
 				CBBAE558295CD6C800F374F1 /* SkinVariant.swift in Sources */,
 				CB9E484A291EF8E100538592 /* HomeView.swift in Sources */,

--- a/skinge-ios/Src/Constants.swift
+++ b/skinge-ios/Src/Constants.swift
@@ -27,4 +27,11 @@ struct Constants {
         
     }
 
+    enum State {
+        case idle
+        case loading
+        case loaded
+        case failed
+    }
+
 }

--- a/skinge-ios/Src/ViewModels/ProductListViewModel.swift
+++ b/skinge-ios/Src/ViewModels/ProductListViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 class ProductListViewModel: ObservableObject {
 
@@ -15,11 +16,25 @@ class ProductListViewModel: ObservableObject {
     @Published var boots = [Boot]()
     @Published var skis = [Ski]()
     @Published var skins = [Skin]()
-    @Published var error = false
+    var selectedProductType: Constants.ProductType = Constants.ProductType.skis
+    
+    var products: Array<Product> {
+        switch selectedProductType {
+            case .bindings:
+                return bindings
+            case .boots:
+                return boots
+            case .skis:
+                return skis
+            case .skins:
+                return skins
+            }
+    }
 
     // MARK: - Private Variables
     
     private var dataStore: DataStore?
+    @Published private(set) var state: Constants.State = .idle
     
     // MARK: Init(s)
     
@@ -29,15 +44,32 @@ class ProductListViewModel: ObservableObject {
     
     // MARK: - Public Functions
     
+    func load(with selectedProductType: Constants.ProductType) {
+        self.selectedProductType = selectedProductType
+        
+        switch selectedProductType {
+        case .bindings:
+            getBindings()
+        case .boots:
+            return getBoots()
+        case .skis:
+            return getSkis()
+        case .skins:
+            return getSkins()
+        }
+    }
+    
     func getProducts<T: Decodable>(productType: Constants.ProductType, completionHandler: @escaping ([T]) -> Void) {
+        state = .loading
     
         dataStore?.getProducts(productType) { (products: [T]?) in
             guard let products = products else {
-                self.error = true
+                self.state = .failed
                 return
             }
             DispatchQueue.main.async {
                 completionHandler(products)
+                self.state = .loaded
             }
         }
     }

--- a/skinge-ios/Src/ViewModels/ProductListViewModel.swift
+++ b/skinge-ios/Src/ViewModels/ProductListViewModel.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import SwiftUI
 
 class ProductListViewModel: ObservableObject {
 

--- a/skinge-ios/Src/Views/ErrorView.swift
+++ b/skinge-ios/Src/Views/ErrorView.swift
@@ -1,0 +1,17 @@
+//
+//  ErrorView.swift
+//  skinge-ios
+//
+//  Created by Cassie Wallace on 12/29/22.
+//
+
+import Foundation
+import SwiftUI
+
+struct ErrorView: View {
+
+    var body: some View {
+        Text("Something went wrong.")
+    }
+
+}

--- a/skinge-ios/Src/Views/GearView.swift
+++ b/skinge-ios/Src/Views/GearView.swift
@@ -9,8 +9,14 @@ import SwiftUI
 
 struct GearView: View {
 
+    // MARK: - Public Variables
+    
     @ObservedObject var viewModel = ProductListViewModel()
     @State var selectedProductType = Constants.ProductType.skis
+    
+    // MARK: - Private Variables
+    
+    private let productTypes = Constants.ProductType.allCases
     
     // MARK: - Body
 
@@ -18,7 +24,7 @@ struct GearView: View {
         NavigationView {
             VStack {
                 Picker("Product Type", selection: $selectedProductType) {
-                    ForEach(Constants.ProductType.allCases, id: \.self) { type in
+                    ForEach(productTypes, id: \.self) { type in
                         Text(type.rawValue.capitalized)
                     }
                 }

--- a/skinge-ios/Src/Views/ProductListView.swift
+++ b/skinge-ios/Src/Views/ProductListView.swift
@@ -14,61 +14,35 @@ struct ProductListView: View {
     @ObservedObject var viewModel: ProductListViewModel
     @Binding public var selectedProductType: Constants.ProductType
     
-    // MARK: - Private Variables
-    
-    private var getProducts: () {
-        switch selectedProductType {
-            case .bindings:
-                return viewModel.getBindings()
-            case .boots:
-                return viewModel.getBoots()
-            case .skis:
-                return viewModel.getSkis()
-            case .skins:
-                return viewModel.getSkins()
-            }
-    }
-    
-    private var products: Array<Product> {
-        switch selectedProductType {
-            case .bindings:
-                return viewModel.bindings
-            case .boots:
-                return viewModel.boots
-            case .skis:
-                return viewModel.skis
-            case .skins:
-                return viewModel.skins
-            }
-    }
-    
     // MARK: - Body
 
     var body: some View {
-        List(products, id: \.id) { product in
-            NavigationLink(destination: ProductDetailView(product: product, productType: selectedProductType)) {
-                VStack(alignment: .leading) {
-                    Text(product.brand)
-                        .italic()
-                    Text(product.name)
-                        .font(.headline)
+        switch viewModel.state {
+        case .idle:
+            Color.clear.onAppear { viewModel.load(with: selectedProductType) }
+        case .loading:
+            ProgressView()
+                .frame(maxHeight: .infinity)
+        case .failed:
+            ErrorView()
+        case .loaded:
+            List(viewModel.products, id: \.id) { product in
+                NavigationLink(destination: ProductDetailView(product: product, productType: selectedProductType)) {
+                        VStack(alignment: .leading) {
+                            Text(product.brand)
+                                .italic()
+                            Text(product.name)
+                                .font(.headline)
+                        }
                 }
             }
+            .listStyle(PlainListStyle())
+            .scrollContentBackground(.hidden)
+            .frame(maxWidth: .infinity)
+            .onChange(of: selectedProductType) { _ in
+                viewModel.load(with: selectedProductType)
+            }
         }
-        .scrollContentBackground(.hidden)
-        .frame(maxWidth: .infinity)
-        .listStyle(PlainListStyle())
-        .alert("Something went wrong", isPresented: $viewModel.error) {
-            Button("OK") { }
-        }
-        // TODO: Implementing Combine could enable these to be combined (no pun intended) into `.onReceive`.
-        .onAppear {
-            getProducts
-        }
-        .onChange(of: selectedProductType) { _ in
-            getProducts
-        }
-        
     }
 
 }


### PR DESCRIPTION
# Add loading indicator to product list

## Changes
- Adding a loading indicator to product list
- Which resulted in ultimately simplifying the Views and moving more to the ViewModel
- Added a very simple `ErrorView()`

## Future work:
- There's more that can be done here in terms of reusability, so linking https://www.swiftbysundell.com/articles/handling-loading-states-in-swiftui/ here (which I referenced with this PR) to come back to in the future.
- Implement on the Product Detail view
- Only display the ProgressView after a few milliseconds (when the datas loads quickly, it looks bad and is pointless, but I don't know how to do this easily)