### PR TITLE
Add variants to Product protocol

### DIFF
--- a/skinge-ios/Src/Models/Product/Boot.swift
+++ b/skinge-ios/Src/Models/Product/Boot.swift
@@ -9,6 +9,9 @@ import Foundation
 
 struct Boot: Product, Codable {
 
+    // MARK: - Typealiases
+    typealias ProductVariant = BootVariant    
+
     // MARK: - Variables
     
     var year: String
@@ -18,7 +21,7 @@ struct Boot: Product, Codable {
     var recommendedUse: String?
     var warranty: String?
     var womensSpecific: Bool?
-    var variants: [BootVariant]?
+    var variants: Array<ProductVariant>?
     var id: Int
     
 }

--- a/skinge-ios/Src/Models/Product/Product.swift
+++ b/skinge-ios/Src/Models/Product/Product.swift
@@ -9,6 +9,10 @@ import Foundation
 
 protocol Product: Codable {
 
+    // MARK: - Associated Types
+    
+    associatedtype ProductVariant
+
     // MARK: - Variables
     
     var year: String { get set }
@@ -18,6 +22,7 @@ protocol Product: Codable {
     var recommendedUse: String? { get set }
     var warranty: String? { get set }
     var womensSpecific: Bool? { get set }
+    var variants: Array<ProductVariant>? { get set }
     var id: Int { get set }
     
 }

--- a/skinge-ios/Src/Models/Product/Ski.swift
+++ b/skinge-ios/Src/Models/Product/Ski.swift
@@ -8,6 +8,9 @@
 import Foundation
 
 struct Ski: Product, Codable, Hashable {
+
+    // MARK: - Typealiases
+    typealias ProductVariant = SkiVariant
     
     // MARK: - Variables
     

--- a/skinge-ios/Src/Models/Product/SkiBinding.swift
+++ b/skinge-ios/Src/Models/Product/SkiBinding.swift
@@ -9,6 +9,9 @@ import Foundation
 
 struct SkiBinding: Product, Codable {
 
+    // MARK: - Typealiases
+    typealias ProductVariant = SkiBindingVariant
+
     // MARK: - Variables
     
     var year: String
@@ -18,7 +21,7 @@ struct SkiBinding: Product, Codable {
     var recommendedUse: String?
     var warranty: String?
     var womensSpecific: Bool?
-    var variants: [SkiBindingVariant]?
+    var variants: Array<ProductVariant>?
     var id: Int
     
 }

--- a/skinge-ios/Src/Models/Product/Skin.swift
+++ b/skinge-ios/Src/Models/Product/Skin.swift
@@ -9,6 +9,9 @@ import Foundation
 
 struct Skin: Product, Codable {
 
+    // MARK: - Typealiases
+    typealias ProductVariant = SkinVariant
+
     // MARK: - Variables
     
     var year: String
@@ -18,7 +21,7 @@ struct Skin: Product, Codable {
     var recommendedUse: String?
     var warranty: String?
     var womensSpecific: Bool?
-    var variants: [SkinVariant]?
+    var variants: Array<ProductVariant>?
     var id: Int
     
 }

--- a/skinge-ios/Src/Modules/Gear/ProductListViewModel.swift
+++ b/skinge-ios/Src/Modules/Gear/ProductListViewModel.swift
@@ -17,7 +17,7 @@ class ProductListViewModel: ObservableObject {
     @Published var skins = [Skin]()
     var selectedProductType: Constants.ProductType = Constants.ProductType.skis
     
-    var products: Array<Product> {
+    var products: Array<any Product> {
         switch selectedProductType {
             case .bindings:
                 return bindings


### PR DESCRIPTION
I couldn't figure this when I initially implemented these models, but after reading https://www.swiftbysundell.com/articles/using-generic-type-constraints-in-swift-4/ (a few times...) I'm implementing this solution.

Not a functional change because I just implemented all the variants without having to conform to a protocol, but I wanted it to be a part of the protocol.